### PR TITLE
fix(regexp): do not use RegExp#compile as deprecated

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,3 @@
+export default class TinySegmenter {
+  segment(text: string): string[]
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,8 +14,7 @@ function TinySegmenter() {
     }
     this.chartype_ = [];
     for (var i in patterns) {
-        var regexp = new RegExp;
-        regexp.compile(i)
+        var regexp = new RegExp(i);
         this.chartype_.push([regexp, patterns[i]]);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkdropapp/tiny-segmenter",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Super compact Japanese tokenizer in Javascript. http://chasen.org/~taku/software/TinySegmenter/",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "description": "Super compact Japanese tokenizer in Javascript. http://chasen.org/~taku/software/TinySegmenter/",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inkdropapp/tiny-segmenter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Super compact Japanese tokenizer in Javascript. http://chasen.org/~taku/software/TinySegmenter/",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tiny-segmenter",
+  "name": "@inkdropapp/tiny-segmenter",
   "version": "0.2.0",
   "description": "Super compact Japanese tokenizer in Javascript. http://chasen.org/~taku/software/TinySegmenter/",
   "main": "lib/index.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/leungwensen/tiny-segmenter.git"
+    "url": "git+https://github.com/inkdropapp/tiny-segmenter.git"
   },
   "keywords": [
     "tiny",
@@ -19,7 +19,7 @@
   "author": "Taku Kudo <taku@chasen.org>",
   "license": "SEE LICENSE IN http://chasen.org/~taku/software/TinySegmenter/LICENCE.txt",
   "bugs": {
-    "url": "https://github.com/leungwensen/tiny-segmenter/issues"
+    "url": "https://github.com/inkdropapp/tiny-segmenter/issues"
   },
-  "homepage": "https://github.com/leungwensen/tiny-segmenter#readme"
+  "homepage": "https://github.com/inkdropapp/tiny-segmenter#readme"
 }


### PR DESCRIPTION
Just call `new RegExp(i)` works as expected.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/compile